### PR TITLE
[CPT-620] 댜중 tyk gw를 subchart로 구성하기 위한 구조 적용 

### DIFF
--- a/tyk-pro/Chart.yaml
+++ b/tyk-pro/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: tyk-pro
-version: 0.13.2-r1
+version: 0.13.2-r2
 icon: https://tyk.io/wp-content/uploads/2021/07/tyk_logo_no_bg.png
 home: https://tyk.io/
 sources:

--- a/tyk-pro/templates/deployment-gw-repset.yaml
+++ b/tyk-pro/templates/deployment-gw-repset.yaml
@@ -115,9 +115,9 @@ spec:
             {{- end }}
         {{- end }}
           - name: TYK_GW_DBAPPCONFOPTIONS_CONNECTIONSTRING
-            value: "{{ include "tyk-pro.dash_proto" . }}://dashboard-svc-{{ include "tyk-pro.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.dash.service.port }}"
+            value: "{{ include "tyk-pro.dash_proto" . }}://dashboard-svc-{{ include "tyk-pro.name" . }}.{{ .Release.Namespace }}:{{ .Values.dash.service.port }}"
           - name: TYK_GW_POLICIES_POLICYCONNECTIONSTRING
-            value: "{{ include "tyk-pro.dash_proto" . }}://dashboard-svc-{{ include "tyk-pro.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.dash.service.port }}"
+            value: "{{ include "tyk-pro.dash_proto" . }}://dashboard-svc-{{ include "tyk-pro.name" . }}.{{ .Release.Namespace }}:{{ .Values.dash.service.port }}"
           - name: TYK_GW_SECRET
             valueFrom:
               secretKeyRef:

--- a/tyk-pro/templates/secret-certs.yaml
+++ b/tyk-pro/templates/secret-certs.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.dash.enabled -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,3 +14,4 @@ data:
     {{ .Files.Get "certs/cert.pem" | b64enc }}
   key.pem: |-
     {{ .Files.Get "certs/key.pem" | b64enc }}
+{{- end }}

--- a/tyk-pro/templates/secret-dashboard.yaml
+++ b/tyk-pro/templates/secret-dashboard.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.dash.enabled -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,3 +15,4 @@ data:
   {{ else }}
   TYK_PASS: {{ randAlphaNum 10 | b64enc | quote }}
   {{ end }}
+{{- end }}


### PR DESCRIPTION
[CPT-620] 댜중 tyk gw를 subchart로 구성하기 위한 구조 적용

- subchart의 공통 이름으로 tyk.name 사용
- gateway가 참조하는 dash svc 이름 변경
- secret template 생성 여부 조건 추가